### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -44,6 +44,7 @@ jobs:
               - name: ArduinoBLE
               - name: Arduino_CMSIS-DSP
             sketch-paths: examples/ScienceKit/Nano33BLESenseFirmware
+            artifact-name-suffix: arduino-mbed_nano-nano33ble-1
           - fqbn: arduino:mbed_nano:nanorp2040connect
             platforms: |
               - name: arduino:mbed_nano
@@ -51,6 +52,7 @@ jobs:
               - name: Arduino_LSM6DSOX
               - name: ArduinoBLE
             sketch-paths: examples/ScienceKit/RP2040ConnectFirmware
+            artifact-name-suffix: arduino-mbed_nano-nanorp2040connect
           - fqbn: arduino:samd:mkrwifi1010
             platforms: |
               - name: arduino:samd
@@ -58,6 +60,7 @@ jobs:
               - name: ArduinoBLE
               - name: Adafruit LSM9DS1 Library
             sketch-paths: examples/ScienceKit/PhysicsLabFirmware
+            artifact-name-suffix: arduino-samd-mkrwifi1010-1
           - fqbn: arduino:mbed_nano:nano33ble
             platforms: |
               - name: arduino:mbed_nano
@@ -72,6 +75,7 @@ jobs:
               - name: ArduinoBLE
               - name: Arduino_CMSIS-DSP
             sketch-paths: examples/ScienceKitR2/Nano33BLESenseFirmware
+            artifact-name-suffix: arduino-mbed_nano-nano33ble-2
           - fqbn: arduino:samd:mkrwifi1010
             platforms: |
               - name: arduino:samd
@@ -82,6 +86,7 @@ jobs:
               - name: INA2xx
               - name: SerialFlash
             sketch-paths: examples/ScienceKitR2/PhysicsLabFirmware
+            artifact-name-suffix: arduino-samd-mkrwifi1010-2
 
     steps:
       - name: Checkout repository
@@ -108,4 +113,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .g