### PR TITLE
Fix for Board non mounting Bosch Accelerometer BMI270

### DIFF
--- a/examples/ScienceKitR2/PhysicsLabFirmware/config.h
+++ b/examples/ScienceKitR2/PhysicsLabFirmware/config.h
@@ -52,7 +52,7 @@ void sensorsInit() {
 
   // LSM6DSOX init
   if (!IMU_SK.begin()) {
-    Serial.println("Failed to initialize ACCELERATOMETER!");
+    Serial.println("Failed to initialize ACCELEROMETER!");
     while (1);
   }
   Serial.println("IMU Initialized");

--- a/examples/ScienceKitR2/PhysicsLabFirmware/config.h
+++ b/examples/ScienceKitR2/PhysicsLabFirmware/config.h
@@ -45,14 +45,14 @@ void sensorsInit() {
   INA.alertOnBusOverVoltage(true, 5000);  // Trigger alert if over 5V on bus
 
   // bmm150
-   if (!BME.begin()) {
-    Serial.println("Failed to initialize IMU!");
+   if (!BME.begin(BOSCH_MAGNETOMETER_ONLY)) {
+    Serial.println("Failed to initialize MAGNETOMETER!");
     while (1);
   }
 
   // LSM6DSOX init
   if (!IMU_SK.begin()) {
-    Serial.println("Failed to initialize IMU!");
+    Serial.println("Failed to initialize ACCELERATOMETER!");
     while (1);
   }
   Serial.println("IMU Initialized");


### PR DESCRIPTION
Some HW revision of the Science Kit rev 2 board does not mount Bosch accelerometer, however the used sensor library (Arduino_BMI270_BMM150) tried to initialize it. Failed initialization lead to a infinite empty loop.

This PR uses a change in the Arduino_BMI270_BMM150 library that allow to select which Bosch sensor are installed (Magnetometer, Accelerometer or both).
The PR selects Magnetometer only.